### PR TITLE
Normalizing image brightness implemented

### DIFF
--- a/python/nii2png.py
+++ b/python/nii2png.py
@@ -38,7 +38,7 @@ def main(argv):
     print('Output folder is ', outputfile)
 
     # set fn as your 4d nifti file
-    image_array = nibabel.load(inputfile).get_data()
+    image_array = nibabel.load(inputfile).get_fdata()
     print(len(image_array.shape))
 
     # ask if rotate


### PR DESCRIPTION
I fixed a bug, that was caused by using `nibabel.load(inputfile).get_data()`. Instead `nibabel.load(inputfile).get_fdata()` should be used (`get_fdata()` instead of `get_data()`).
Besides that, I implemented the normalization of the input image brightness. This way, all output images have the same brightness and contrast, resulting in a heterogeneous image sequence. The issue was caused by the fact, that NIFTI images have brightness values from -3000 to 3000, but PNGs only from 0 to 255. This was solved with a basic linear transformation.